### PR TITLE
Fix warnings

### DIFF
--- a/lib/redis/persistence.rb
+++ b/lib/redis/persistence.rb
@@ -381,7 +381,7 @@ class Redis
       # Returns whether record is saved into database
       #
       def persisted?
-        __redis.exists __redis_key
+        __redis.exists? __redis_key
       end
 
       def inspect

--- a/test/_helper.rb
+++ b/test/_helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
 
-require 'test/unit'
+require 'minitest/unit'
 require 'shoulda'
 require 'turn' unless ENV["TM_FILEPATH"] || ENV["CI"]
 require 'mocha/setup'

--- a/test/_helper.rb
+++ b/test/_helper.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'minitest/unit'
 require 'shoulda'
 require 'turn' unless ENV["TM_FILEPATH"] || ENV["CI"]
-require 'mocha/setup'
+require 'mocha/minitest'
 
 require 'active_support/core_ext/hash/indifferent_access'
 
@@ -12,7 +12,7 @@ require 'yajl'
 
 require 'models'
 
-class Test::Unit::TestCase
+class Minitest::Test
 
   def setup
     Redis::Persistence.config.redis = Redis.new db: ENV['REDIS_PERSISTENCE_TEST_DATABASE'] || 14

--- a/test/active_model_lint_test.rb
+++ b/test/active_model_lint_test.rb
@@ -3,7 +3,7 @@ require '_helper'
 class Redis
   module Persistence
 
-    class ActiveModelLintTest < Test::Unit::TestCase
+    class ActiveModelLintTest < MiniTest::Unit::TestCase
 
       include ActiveModel::Lint::Tests
 

--- a/test/redis_persistence_test.rb
+++ b/test/redis_persistence_test.rb
@@ -143,7 +143,7 @@ class RedisPersistenceTest < ActiveSupport::TestCase
       m = ModelWithFamily.new name: 'One'
       m.save
 
-      assert in_redis.exists('model_with_families:1'), in_redis.keys.to_s
+      assert in_redis.exists?('model_with_families:1'), in_redis.keys.to_s
       assert in_redis.hkeys('model_with_families:1').include?('default')
     end
 
@@ -152,7 +152,7 @@ class RedisPersistenceTest < ActiveSupport::TestCase
       m.save
 
       assert_equal 1, m.id
-      assert in_redis.exists('model_with_families:1'), in_redis.keys.to_s
+      assert in_redis.exists?('model_with_families:1'), in_redis.keys.to_s
       assert in_redis.hkeys('model_with_families:1').include?('default'),  in_redis.hkeys('model_with_families:1').to_s
       assert in_redis.hkeys('model_with_families:1').include?('counters'), in_redis.hkeys('model_with_families:1').to_s
 
@@ -314,7 +314,7 @@ class RedisPersistenceTest < ActiveSupport::TestCase
     should "be saved and found in Redis" do
       article = PersistentArticle.new title: 'One'
       assert article.save
-      assert in_redis.exists("persistent_articles:1")
+      assert in_redis.exists?("persistent_articles:1")
 
       assert_equal 1, PersistentArticle.all.size
       assert_not_nil  PersistentArticle.find(1)


### PR DESCRIPTION
Fix a lot of warnings 
```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/app/vendor/bundle/ruby/2.6.0/gems/redis-persistence-0.1.0/lib/redis/persistence.rb:384:in `persisted?')
```